### PR TITLE
customize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+.vscode/
+*.json
+*.txt
+temp/*
+.idea/*

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ git clone https://github.com/RSRH-Rs/webscreenshot.git
 2.依赖：
 
 ```
-pip install aiohttp~=3.8.4
-pip install playwright~=1.32.1
+pip install -r requirements.txt
 playwright install
 ```
 
@@ -30,16 +29,18 @@ playwright install
 当有以 http/https 开头的链接会自动发送网页截图
 
 4.配置文件
-在 config.py 里面设置是否开启绿标检测
+指令：`切换绿标检测状态 + false/关闭`，除了`false/关闭`以外的任何输入都会将设置重置为`True`
 如果不开，群友发什么网站都会截图(包括色情暴力)
-
-```
-qq_certification_status: bool = True  # 是否开启QQ绿标检测
-```
 
 ## 其他
 
 Linux 和 Windows 都已测过，完美运行~
-Linux 安装 playwright 的话看具体提示(貌似是`apt install playwright-dev`，我也忘了，具体看调用 playwright 报错信息)
+~~Linux 安装 playwright 的话看具体提示(貌似是`apt install playwright-dev`，我也忘了，具体看调用 playwright 报错信息)~~
 
 **渣代码,欢迎提出改进建议~**
+Pull Request lists:
+- 添加`切换绿标检测状态`，无需再手动改动代码文件
+- 添加`requirements.txt`，一键安装依赖
+- 移除`get_path()`函数，实际使用问题很多，直接在每个需要的位置手动配置相对路径会更安全
+- 使用`pillow`库对截图进行压缩，防止图片太大被QQ风控
+- 绿标检测更改为`aiorequests.get()`，这个函数本身就是异步的，同时配置请求头防止获取失败

--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,7 @@
-import os
-from hoshino import Service, priv, R
+import hoshino.config
+from hoshino import Service, priv, HoshinoBot
 from hoshino.typing import CQEvent
 from .utils import *
-from nonebot import MessageSegment
-
 
 sv_help = """
 网页截图/预览
@@ -15,48 +13,93 @@ sv_help = """
 #[网页截图/预览] https://www.baidu.com
 """.strip()
 sv = Service(
-    name="webscreenshot",  # 功能名
+    name="网页截图",  # 功能名
     use_priv=priv.NORMAL,  # 使用权限
     manage_priv=priv.ADMIN,  # 管理权限
-    visible=True,  # 可见性
-    enable_on_default=True,  # 默认启用
+    visible=False,  # 可见性
+    enable_on_default=False,  # 默认启用
     bundle="功能",  # 分组归类
     help_=sv_help  # 帮助说明
 )
 
 
-@sv.on_fullmatch(("网页截图帮助", "网页预览帮助"), only_to_me=False)
-async def sendHelp(bot, ev):
+@sv.on_fullmatch("帮助网页截图")
+async def bangzhu(bot: HoshinoBot, ev: CQEvent):
     await bot.send(ev, sv_help)
 
 
-@sv.on_prefix(('网页截图', '网页预览', '截图', '预览'), only_to_me=False)
-async def screenshot(bot, ev: CQEvent):
-    uid = str(ev.user_id)
-    url = str(ev.message.extract_plain_text()).strip()
-    message_id = int(ev.message_id)
-    save_path = get_path("temp")
-    nowtime = str(getNowtime())
-    result = await screen_shot(url, nowtime)
+@sv.on_prefix(('网页截图', '网页预览', '截图', '预览'))
+async def screenshot(bot: HoshinoBot, ev: CQEvent):
+    url = ev.message.extract_plain_text().strip()
+    gid = str(ev.group_id)
+    message_id = ev.message_id
+    time_present = get_present_time()
+    result = await screen_shot(url, time_present, gid)
     if result != "success":
-        await bot.finish(ev,MessageSegment.reply(message_id)+result)
+        await bot.finish(ev, MessageSegment.reply(message_id) + result)
         # await bot.finish(ev, f"[CQ:reply,id={message_id}][CQ:at,qq={uid}]{result}")
-
-    await bot.send(ev, f"{MessageSegment.image(f'file:///{get_path(save_path,nowtime)}.png')}")
-    os.remove(fr'{get_path(save_path,nowtime)}.png')
+    img_path = os.path.join(save_path, f"{time_present}.png")
+    hoshino.logger.info(img_path)
+    await bot.send(ev, f"{gen_ms_img(Image.open(img_path))}")
+    os.remove(img_path)
     # print("图片移除成功！")
 
 
-@sv.on_prefix(('http', 'https'), only_to_me=False)
-async def preview(bot, ev: CQEvent):
-    url = str(ev.raw_message).strip()
-    uid = str(ev.user_id)
-    nowtime = str(getNowtime())
+@sv.on_prefix(('http://', 'https://'))  # noqa
+async def preview(bot: HoshinoBot, ev: CQEvent):
+    if not priv.check_priv(ev, priv.ADMIN):
+        return
+    url = ev.raw_message.strip()
+    gid = str(ev.group_id)
+    time_present = get_present_time()
     message_id = int(ev.message_id)
-    save_path = get_path("temp")
-    result = await screen_shot(url, nowtime)
+    result = await screen_shot(url, time_present, gid)
     if result != "success":
-        await bot.finish(ev,MessageSegment.reply(message_id)+result)
-    await bot.send(ev, f"{MessageSegment.image(f'file:///{get_path(save_path,nowtime)}.png')}")
-    os.remove(fr'{get_path(save_path,nowtime)}.png')
+        await bot.finish(ev, MessageSegment.reply(message_id) + result)
+    img_path = os.path.join(save_path, f"{time_present}.png")
+    hoshino.logger.info(img_path)
+    await bot.send(ev, f"{gen_ms_img(Image.open(img_path))}")
+    os.remove(img_path)
     # print("图片移除成功！")
+
+
+@sv.on_prefix("切换绿标检测状态")
+async def switch_website_mark(bot: HoshinoBot, ev: CQEvent):
+    if not priv.check_priv(ev, priv.ADMIN):
+        await bot.finish(ev, '此命令仅群管可用~')
+    msg = ev.message.extract_plain_text().strip()
+    status = True
+    if re.match("关闭|false", msg, re.I):
+        status = False
+    basic_config = {
+        "status": status
+    }
+    gid = str(ev.group_id)
+    if os.path.exists(config_path):
+        try:
+            configs = json.load(open(config_path, encoding="utf-8"))
+            if gid in configs:
+                if not msg:
+                    configs[gid]["status"] = not configs[gid]["status"]
+                else:
+                    configs[gid]["status"] = status
+                with open(config_path, "w", encoding="utf-8") as f:
+                    f.write(json.dumps(configs, indent=2, ensure_ascii=False))
+                await bot.send(ev, f"本群绿标检测状态已切换为{status}")
+                return
+            else:
+                configs[gid] = basic_config
+                with open(config_path, "w", encoding="utf-8") as f:
+                    f.write(json.dumps(configs, indent=2, ensure_ascii=False))
+                await bot.send(ev, f"本群绿标检测状态已切换为{status}")
+                return
+
+        except json.decoder.JSONDecodeError:
+            pass
+
+    configs = {
+        gid: basic_config
+    }
+    with open(config_path, "w", encoding="utf-8") as f:
+        f.write(json.dumps(configs, indent=2, ensure_ascii=False))
+    await bot.send(ev, f"本群绿标检测状态已切换为{status}")

--- a/config.py
+++ b/config.py
@@ -1,1 +1,0 @@
-qq_certification_status: bool = True  # 是否开启QQ绿标检测

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+aiohttp~=3.8.4
+pillow
+playwright~=1.32.1

--- a/utils.py
+++ b/utils.py
@@ -1,26 +1,63 @@
+import asyncio
+import io
+import json
 import os
 import re
-from playwright.async_api import async_playwright
-import asyncio
-import os
 from datetime import datetime
-from requests import get
-from typing import Optional
+from typing import Optional, Union
+
+from PIL import Image
+from playwright.async_api import async_playwright
+
 import hoshino
-from .config import qq_certification_status
-from aiohttp.client import ClientSession
+from hoshino import util, aiorequests
+from hoshino.typing import MessageSegment
 
-file_path = "temp"
-qq_certification_status:bool = qq_certification_status
+# qq_certification_status: bool = True  # 是否开启QQ绿标检测
+basic_path = os.path.dirname(__file__)
+save_path = os.path.join(basic_path, "temp")
+config_path = os.path.join(basic_path, "config.json")
+txt_path = os.path.join(basic_path, "certified_websites.txt")
+if not os.path.exists(txt_path):
+    open(txt_path, "w")
 
-def getNowtime() -> int:
+headers = {
+    "User-Agent": "Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-CN; rv:1.9.1.6) ",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+    "Accept-Language": "zh-cn"
+}
+
+
+def gen_ms_img(image: Union[bytes, Image.Image]) -> MessageSegment:
+    if isinstance(image, bytes):
+        return MessageSegment.image(
+            util.pic2b64(Image.open(io.BytesIO(image)))
+        )
+    else:
+        return MessageSegment.image(
+            util.pic2b64(image)
+        )
+
+
+def get_present_time() -> int:
     return int(datetime.timestamp(datetime.now()))
 
 
-async def screen_shot(url: str, nowTime: int) -> Optional[str or bool]:
+async def screen_shot(url: str, time_present: int, gid: str) -> Optional[str or bool]:
     all_domains = get_txt()
     domain = get_domain(url)[0]
-    save_path = get_path(file_path)
+
+    if os.path.exists(config_path):
+        try:
+            configs = json.load(open(config_path, encoding="utf-8"))
+            if gid in configs:
+                qq_certification_status = configs[gid]["status"]
+            else:
+                qq_certification_status = True
+        except json.decoder.JSONDecodeError:
+            qq_certification_status = True
+    else:
+        qq_certification_status = True
 
     if qq_certification_status:
         if domain not in all_domains:
@@ -42,40 +79,45 @@ async def screen_shot(url: str, nowTime: int) -> Optional[str or bool]:
         except Exception as e:
             return f"访问网站超时{type(e)}`{e}`"
         await asyncio.sleep(1)
-        hoshino.logger.error("[Warning]正在保存图片...")
-        await page.screenshot(path=fr"{get_path(save_path,str(nowTime))}.png", full_page=True)
-        hoshino.logger.error("[Warning]图片保存成功！")
+        hoshino.logger.info("正在保存图片...")
+        img_path = os.path.join(save_path, f'{time_present}.png')
+        await page.screenshot(
+            path=img_path,
+            full_page=True
+        )
+        hoshino.logger.info("正在压缩图片...")
+        img_convert = Image.open(img_path)
+        img_convert.save(img_path, quality=70)
+        hoshino.logger.info("图片保存成功！")
         await browser.close()
         return "success"
 
 
 def update_txt(content: str, file_name: str = "certified_websites.txt"):
-    file_path = get_path(file_name)
+    file_path = os.path.join(basic_path, file_name)
     with open(file_path, mode="a+") as f:
         f.writelines("\n" + content)
 
 
 def get_txt(file_name: str = "certified_websites.txt") -> list:
-    file_path = get_path(file_name)
+    file_path = os.path.join(basic_path, file_name)
     with open(file_path, mode="r") as f:
         return f.read().strip().split("\n")
 
 
-
 async def get_url_certified_state(url: str) -> dict:
-    hoshino.logger.error("[Warning]正在获取QQ绿标数据...")
-    api = "https://www.yuanxiapi.cn/api/qqurlsec/?url=%s"
-    async with ClientSession() as session:
-        try:
-            async with session.get(url=api%url) as response:
-                result = await response.json()
-                return result
-        except Exception as e:
-            hoshino.logger.error(f"[Error] 网站{url}获取QQ绿标数据错误。{type(e)}")
-            return {}
-
-def get_path(*paths) -> str:
-    return os.path.join(os.path.dirname(__file__), *paths)
+    hoshino.logger.info("正在获取QQ绿标数据...")
+    api = f"https://www.yuanxiapi.cn/api/qqurlsec/?url={url}"
+    # async with ClientSession(headers=headers, timeout=20) as session:
+    try:
+        resp = await aiorequests.get(api, headers=headers, timeout=20)
+        result = json.loads(await resp.content)
+        # async with session.get(url=api) as response:
+        #     result = (await response).json()
+        return result
+    except Exception as e:
+        hoshino.logger.error(f"网站{url}获取QQ绿标数据错误。{type(e)}")
+        return {}
 
 
 def get_domain(urls: Optional[list or str] = get_txt) -> list:
@@ -86,7 +128,7 @@ def get_domain(urls: Optional[list or str] = get_txt) -> list:
         regex = r'(?:https?://)?(?:www\.)?([a-zA-Z0-9-]+\.[a-zA-Z0-9.-]+)'
         result = re.findall(regex, url)
         if not result:
-            hoshino.logger.error(f"[Error] Url{url} 未能找到域名")
+            hoshino.logger.error(f"Url{url} 未能找到域名")
             continue
         results.append(result[0])
 


### PR DESCRIPTION
- 添加`切换绿标检测状态`，无需再手动改动代码文件
- 添加`requirements.txt`，一键安装依赖
- 移除`get_path()`函数，实际使用问题很多，直接在每个需要的位置手动配置相对路径会更安全
- 使用`pillow`库对截图进行压缩，防止图片太大被QQ风控
- 绿标检测更改为`aiorequests.get()`，这个函数本身就是异步的，同时配置请求头防止获取失败